### PR TITLE
use lane name instead of lane_id as unique identifier

### DIFF
--- a/modules/PipelinesReporting/LaneEmail.pm
+++ b/modules/PipelinesReporting/LaneEmail.pm
@@ -7,7 +7,7 @@ LaneEmails.pm   - Records if an email has been sent for different actions on a l
 use PipelinesReporting::LaneEmails;
 my $lane_email = PipelinesReporting::LaneEmails->new(
   _dbh => $dbh,
-  lane_id => 1234
+  name => 1234
   );
 $lane_email->is_qc_email_sent();
 $lane_email->is_mapping_email_sent();
@@ -19,7 +19,7 @@ use Moose;
 use PipelinesReporting::Schema;
 
 has '_dbh'        => ( is => 'rw', required   => 1 );
-has 'lane_id'     => ( is => 'rw', isa => 'Int', required   => 1 );
+has 'name'        => ( is => 'rw', isa => 'Str', required   => 1 );
 has 'lane_email'  => ( is => 'rw', lazy_build   => 1 );
 
 
@@ -29,7 +29,7 @@ sub _build_lane_email
   my $lane_email_rs = $self->_lane_email_rs();
   unless(defined $lane_email_rs)
   {
-    $lane_email_rs   = $self->_dbh->resultset('LaneEmails')->create({ lane_id => $self->lane_id, qc_email_sent => 0, mapping_email_sent => 0 });
+    $lane_email_rs   = $self->_dbh->resultset('LaneEmails')->create({ name => $self->name, qc_email_sent => 0, mapping_email_sent => 0 });
   }
   return $lane_email_rs;
 }
@@ -38,7 +38,7 @@ sub _lane_email_rs
 {
   my ($self) = @_;
   my $lane_email_rs = $self->_dbh->resultset('LaneEmails')->search(
-    { lane_id =>  $self->lane_id }
+    { name =>  $self->name }
   )->first;
   
   return $lane_email_rs;

--- a/modules/PipelinesReporting/Schema/Result/Lane.pm
+++ b/modules/PipelinesReporting/Schema/Result/Lane.pm
@@ -4,7 +4,7 @@ use base qw/DBIx::Class::Core/;
 # pipeline database
 
 __PACKAGE__->table('latest_lane');
-__PACKAGE__->add_columns(qw/row_id lane_id library_id processed/);
+__PACKAGE__->add_columns(qw/row_id name lane_id library_id processed/);
 __PACKAGE__->set_primary_key('row_id');
 __PACKAGE__->belongs_to(library => 'PipelinesReporting::Schema::Result::Library', { 'foreign.library_id' => 'self.library_id' });
 

--- a/modules/PipelinesReporting/Schema/Result/LaneEmails.pm
+++ b/modules/PipelinesReporting/Schema/Result/LaneEmails.pm
@@ -4,7 +4,7 @@ use base qw/DBIx::Class::Core/;
 # QC database
 
 __PACKAGE__->table('lane_emails');
-__PACKAGE__->add_columns('lane_id' , 'qc_email_sent' , 'mapping_email_sent' );
-__PACKAGE__->set_primary_key('lane_id');
+__PACKAGE__->add_columns('name' , 'qc_email_sent' , 'mapping_email_sent' );
+__PACKAGE__->set_primary_key('name');
 
 1;

--- a/sql/Pathogens_QC_Grind.sql
+++ b/sql/Pathogens_QC_Grind.sql
@@ -7,8 +7,8 @@ CREATE TABLE `user_studies` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE TABLE `lane_emails` (
-  `lane_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255)  NOT NULL,
   `qc_email_sent` tinyint(1) DEFAULT 0,
   `mapping_email_sent` tinyint(1) DEFAULT 0,
-  PRIMARY KEY (`lane_id`)
+  PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/t/LaneEmail.t
+++ b/t/LaneEmail.t
@@ -12,25 +12,25 @@ BEGIN {
 
 # setup test databases with seed data
 my $dbh = DBICx::TestDatabase->new('PipelinesReporting::Schema');
-$dbh->resultset('LaneEmails')->create({ lane_id => 1, qc_email_sent => 0, mapping_email_sent => 0});
-$dbh->resultset('LaneEmails')->create({ lane_id => 2, qc_email_sent => 1, mapping_email_sent => 0});
-$dbh->resultset('LaneEmails')->create({ lane_id => 3, qc_email_sent => 1, mapping_email_sent => 1});
+$dbh->resultset('LaneEmails')->create({ name => 1, qc_email_sent => 0, mapping_email_sent => 0});
+$dbh->resultset('LaneEmails')->create({ name => 2, qc_email_sent => 1, mapping_email_sent => 0});
+$dbh->resultset('LaneEmails')->create({ name => 3, qc_email_sent => 1, mapping_email_sent => 1});
 
 # correctly retrieve email sent for each lane
-ok my $lane_email_1 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,lane_id => 1), 'initialize 00';
+ok my $lane_email_1 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 1), 'initialize 00';
 is $lane_email_1->is_qc_email_sent(), 0, 'qc email sent false';
 is $lane_email_1->is_mapping_email_sent(), 0, 'mapping email sent false';
 
-ok my $lane_email_2 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,lane_id => 2), 'initialize 10';
+ok my $lane_email_2 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 2), 'initialize 10';
 is $lane_email_2->is_qc_email_sent(), 1, 'qc email sent true';
 is $lane_email_2->is_mapping_email_sent(), 0, 'mapping email sent false';
 
-ok my $lane_email_3 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,lane_id => 3), 'initialize 11';
+ok my $lane_email_3 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 3), 'initialize 11';
 is $lane_email_3->is_qc_email_sent(), 1, 'qc email sent true';
 is $lane_email_3->is_mapping_email_sent(), 1, 'mapping email sent true';
 
 # previously unseen lane
-ok my $lane_email_unseen = PipelinesReporting::LaneEmails->new(_dbh => $dbh,lane_id => 9), 'initialize unseen lane';
+ok my $lane_email_unseen = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 9), 'initialize unseen lane';
 is $lane_email_unseen->is_qc_email_sent(), 0, 'qc email sent false';
 is $lane_email_unseen->is_mapping_email_sent(), 0, 'mapping email sent false';
 ok $lane_email_unseen->qc_email_sent(), 'send qc email';
@@ -39,6 +39,6 @@ is $lane_email_unseen->is_qc_email_sent(), 1, 'qc email sent false';
 is $lane_email_unseen->is_mapping_email_sent(), 1, 'mapping email sent false';
 
 # look up unseen lane again (because it should now be stored in database
-ok $lane_email_unseen = PipelinesReporting::LaneEmails->new(_dbh => $dbh,lane_id => 9), 'initialize unseen lane';
+ok $lane_email_unseen = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 9), 'initialize unseen lane';
 is $lane_email_unseen->is_qc_email_sent(), 1, 'qc email sent false';
 is $lane_email_unseen->is_mapping_email_sent(), 1, 'mapping email sent false';

--- a/t/Study.t
+++ b/t/Study.t
@@ -23,9 +23,9 @@ $dbh->resultset('Sample'     )->create({ row_id => 1, sample_id  => 3, project_i
 $dbh->resultset('Library'    )->create({ row_id => 1, library_id => 4, sample_id  => 3 });
 $dbh->resultset('Library'    )->create({ row_id => 2, library_id => 7, sample_id  => 3 });
 
-$dbh->resultset('Lane'       )->create({ row_id => 1, lane_id => 5, library_id => 4, processed => 7 });
-$dbh->resultset('Lane'       )->create({ row_id => 2, lane_id => 6, library_id => 4, processed => 3 });
-$dbh->resultset('Lane'       )->create({ row_id => 3, lane_id => 8, library_id => 7, processed => 3 });
+$dbh->resultset('Lane'       )->create({ row_id => 1, name => "abc_1", lane_id => 5, library_id => 4, processed => 7 });
+$dbh->resultset('Lane'       )->create({ row_id => 2, name => "abc_2", lane_id => 6, library_id => 4, processed => 3 });
+$dbh->resultset('Lane'       )->create({ row_id => 3, name => "abc_3", lane_id => 8, library_id => 7, processed => 3 });
 
 
 # valid study
@@ -43,29 +43,30 @@ ok my $study = PipelinesReporting::Study->new(
 my @user_emails = ('aaa@example.com','bbb@example.com');
 is_deeply $study->user_emails, \@user_emails, 'user emails';
 
-my @qc_lane_ids  = (6,8);
-is_deeply $study->qc_lane_ids, \@qc_lane_ids, 'qc lane ids';
+my %qc_names  = (abc_2 => 6,
+                 abc_3 => 8);
+is_deeply $study->qc_names, \%qc_names, 'qc lane ids';
 
-my @mapped_lane_ids = (5);
-is_deeply $study->mapped_lane_ids, \@mapped_lane_ids, 'mapped lane ids';
+my %mapped_names = (abc_1 => 5);
+is_deeply $study->mapped_names, \%mapped_names, 'mapped lane ids';
 
 # check body of constructed email
 my $expected_email_body = 'The following lanes have finished QC in Study Study Name.
 
-http://example.com?mode=0&lane_id=6&db=test
-http://example.com?mode=0&lane_id=8&db=test
+abc_2	http://example.com?mode=0&lane_id=6&db=test
+abc_3	http://example.com?mode=0&lane_id=8&db=test
 
 ';
 
-is $study->_construct_email_body_for_lane_action('QC', $study->qc_lane_ids), $expected_email_body, 'QC email body';
+is $study->_construct_email_body_for_lane_action('QC', $study->qc_names), $expected_email_body, 'QC email body';
 
 
 $expected_email_body = 'The following lanes have finished Mapping in Study Study Name.
 
-http://example.com?mode=0&lane_id=5&db=test
+abc_1	http://example.com?mode=0&lane_id=5&db=test
 
 ';
-is $study->_construct_email_body_for_lane_action('Mapping', $study->mapped_lane_ids), $expected_email_body, 'Mapping email body';
+is $study->_construct_email_body_for_lane_action('Mapping', $study->mapped_names), $expected_email_body, 'Mapping email body';
 
 
 
@@ -81,8 +82,8 @@ ok $study = PipelinesReporting::Study->new(
   email_domain => 'example.com'
 ), 'initialise invalid study';
 is_deeply $study->user_emails, \@empty_array , 'user emails invalid study';
-is_deeply $study->qc_lane_ids, undef, 'qc lane ids undef if invalid study';
-is_deeply $study->mapped_lane_ids, undef, 'mapped lane ids undef if invalid study';
+is_deeply $study->qc_names, undef, 'qc lane ids undef if invalid study';
+is_deeply $study->mapped_names, undef, 'mapped lane ids undef if invalid study';
 
 ok $study = PipelinesReporting::Study->new(  
   _pipeline_dbh => $dbh,
@@ -94,8 +95,8 @@ ok $study = PipelinesReporting::Study->new(
   email_domain => 'example.com'
 ), 'initialise study with no users';
 is_deeply $study->user_emails, \@empty_array, 'user emails empty';
-is_deeply $study->qc_lane_ids, undef, 'qc lane ids undef if no users';
-is_deeply $study->mapped_lane_ids, undef, 'mapped lane ids undef if no users';
+is_deeply $study->qc_names, undef, 'qc lane ids undef if no users';
+is_deeply $study->mapped_names, undef, 'mapped lane ids undef if no users';
 
 # add a user for the study and lane ids should be empty
 $dbh->resultset('UserStudies')->create({ sequencescape_study_id => 10, username => 'aaa'});
@@ -109,6 +110,7 @@ ok $study = PipelinesReporting::Study->new(
   email_domain => 'example.com'
 ), 'initialise study with no users';
 @user_emails = ('aaa@example.com');
+my %empty_hash =();
 is_deeply $study->user_emails, \@user_emails, 'user emails has 1 user';
-is_deeply $study->qc_lane_ids, \@empty_array, 'qc lane ids empty if no lanes';
-is_deeply $study->mapped_lane_ids, \@empty_array, 'mapped lane ids empty if no lanes';
+is_deeply $study->qc_names, \%empty_hash, 'qc lane ids empty if no lanes';
+is_deeply $study->mapped_names, \%empty_hash, 'mapped lane ids empty if no lanes';


### PR DESCRIPTION
lane_id is only unique to the tracking databases but name should be unique across all of them, assuming there are not duplicate studies in different tracking databases
