### PR TITLE
Addition of emails for assembly and annotation

### DIFF
--- a/lib/PipelinesReporting/LaneEmail.pm
+++ b/lib/PipelinesReporting/LaneEmail.pm
@@ -29,7 +29,7 @@ sub _build_lane_email
   my $lane_email_rs = $self->_lane_email_rs();
   unless(defined $lane_email_rs)
   {
-    $lane_email_rs   = $self->_dbh->resultset('LaneEmails')->create({ name => $self->name, qc_email_sent => 0, mapping_email_sent => 0 });
+    $lane_email_rs   = $self->_dbh->resultset('LaneEmails')->create({ name => $self->name, qc_email_sent => 0, mapping_email_sent => 0, assembly_email_sent =>0, annotation_email_sent =>0});
   }
   return $lane_email_rs;
 }
@@ -56,6 +56,18 @@ sub is_mapping_email_sent
   return $self->lane_email->mapping_email_sent;
 }
 
+sub is_assembly_email_sent
+{
+  my ($self) = @_;
+  return $self->lane_email->assembly_email_sent;
+}
+
+sub is_annotation_email_sent
+{
+  my ($self) = @_;
+  return $self->lane_email->annotation_email_sent;
+}
+
 sub qc_email_sent
 {
   my ($self) = @_;
@@ -67,6 +79,20 @@ sub mapping_email_sent
 {
   my ($self) = @_;
   $self->lane_email->mapping_email_sent(1);
+  $self->lane_email->update;
+}
+
+sub assembly_email_sent
+{
+  my ($self) = @_;
+  $self->lane_email->assembly_email_sent(1);
+  $self->lane_email->update;
+}
+
+sub annotation_email_sent
+{
+  my ($self) = @_;
+  $self->lane_email->annotation_email_sent(1);
   $self->lane_email->update;
 }
 

--- a/lib/PipelinesReporting/Schema/Result/LaneEmails.pm
+++ b/lib/PipelinesReporting/Schema/Result/LaneEmails.pm
@@ -4,7 +4,7 @@ use base qw/DBIx::Class::Core/;
 # QC database
 
 __PACKAGE__->table('lane_emails');
-__PACKAGE__->add_columns('name' , 'qc_email_sent' , 'mapping_email_sent' );
+__PACKAGE__->add_columns('name' , 'qc_email_sent' , 'mapping_email_sent', 'assembly_email_sent', 'annotation_email_sent' );
 __PACKAGE__->set_primary_key('name');
 
 1;

--- a/sql/Pathogens_QC_Grind.sql
+++ b/sql/Pathogens_QC_Grind.sql
@@ -10,7 +10,7 @@ CREATE TABLE `lane_emails` (
   `name` varchar(255)  NOT NULL,
   `qc_email_sent` tinyint(1) DEFAULT 0,
   `mapping_email_sent` tinyint(1) DEFAULT 0,
- `assembly_email_sent` tinyint(1) DEFAULT 0,
- `annotation_email_sent` tinyint(1) DEFAULT 0,
+  `assembly_email_sent` tinyint(1) DEFAULT 0,
+  `annotation_email_sent` tinyint(1) DEFAULT 0,
   PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/sql/Pathogens_QC_Grind.sql
+++ b/sql/Pathogens_QC_Grind.sql
@@ -10,5 +10,7 @@ CREATE TABLE `lane_emails` (
   `name` varchar(255)  NOT NULL,
   `qc_email_sent` tinyint(1) DEFAULT 0,
   `mapping_email_sent` tinyint(1) DEFAULT 0,
+ `assembly_email_sent` tinyint(1) DEFAULT 0,
+ `annotation_email_sent` tinyint(1) DEFAULT 0,
   PRIMARY KEY (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/t/LaneEmail.t
+++ b/t/LaneEmail.t
@@ -4,7 +4,7 @@ use warnings;
 
 BEGIN { unshift(@INC, './lib') }
 BEGIN {
-    use Test::Most tests => 20;
+    use Test::Most tests => 44;
     use DBICx::TestDatabase;
     use PipelinesReporting::Schema;
     use_ok('PipelinesReporting::LaneEmail');
@@ -12,33 +12,61 @@ BEGIN {
 
 # setup test databases with seed data
 my $dbh = DBICx::TestDatabase->new('PipelinesReporting::Schema');
-$dbh->resultset('LaneEmails')->create({ name => 1, qc_email_sent => 0, mapping_email_sent => 0});
-$dbh->resultset('LaneEmails')->create({ name => 2, qc_email_sent => 1, mapping_email_sent => 0});
-$dbh->resultset('LaneEmails')->create({ name => 3, qc_email_sent => 1, mapping_email_sent => 1});
+$dbh->resultset('LaneEmails')->create({ name => 1, qc_email_sent => 0, mapping_email_sent => 0, assembly_email_sent =>0, annotation_email_sent =>0});
+$dbh->resultset('LaneEmails')->create({ name => 2, qc_email_sent => 1, mapping_email_sent => 0, assembly_email_sent =>0, annotation_email_sent =>0});
+$dbh->resultset('LaneEmails')->create({ name => 3, qc_email_sent => 1, mapping_email_sent => 1, assembly_email_sent =>0, annotation_email_sent =>0});
+$dbh->resultset('LaneEmails')->create({ name => 4, qc_email_sent => 1, mapping_email_sent => 1, assembly_email_sent =>1, annotation_email_sent =>0});
+$dbh->resultset('LaneEmails')->create({ name => 5, qc_email_sent => 1, mapping_email_sent => 1, assembly_email_sent =>1, annotation_email_sent =>1});
 
 # correctly retrieve email sent for each lane
-ok my $lane_email_1 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 1), 'initialize 00';
+ok my $lane_email_1 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 1), 'initialize 0000';
 is $lane_email_1->is_qc_email_sent(), 0, 'qc email sent false';
 is $lane_email_1->is_mapping_email_sent(), 0, 'mapping email sent false';
+is $lane_email_1->is_assembly_email_sent(), 0, 'assembly email sent false';
+is $lane_email_1->is_annotation_email_sent(), 0, 'annotation email sent false';
 
-ok my $lane_email_2 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 2), 'initialize 10';
+ok my $lane_email_2 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 2), 'initialize 1000';
 is $lane_email_2->is_qc_email_sent(), 1, 'qc email sent true';
 is $lane_email_2->is_mapping_email_sent(), 0, 'mapping email sent false';
+is $lane_email_2->is_assembly_email_sent(), 0, 'assembly email sent false';
+is $lane_email_2->is_annotation_email_sent(), 0, 'annotation email sent false';
 
-ok my $lane_email_3 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 3), 'initialize 11';
+ok my $lane_email_3 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 3), 'initialize 1100';
 is $lane_email_3->is_qc_email_sent(), 1, 'qc email sent true';
 is $lane_email_3->is_mapping_email_sent(), 1, 'mapping email sent true';
+is $lane_email_3->is_assembly_email_sent(), 0, 'assembly email sent false';
+is $lane_email_3->is_annotation_email_sent(), 0, 'annotation email sent false';
+
+ok my $lane_email_4 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 4), 'initialize 1110';
+is $lane_email_4->is_qc_email_sent(), 1, 'qc email sent true';
+is $lane_email_4->is_mapping_email_sent(), 1, 'mapping email sent true';
+is $lane_email_4->is_assembly_email_sent(), 1, 'assembly email sent true';
+is $lane_email_4->is_annotation_email_sent(), 0, 'annotation email sent false';
+
+ok my $lane_email_5 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 5), 'initialize 1111';
+is $lane_email_5->is_qc_email_sent(), 1, 'qc email sent true';
+is $lane_email_5->is_mapping_email_sent(), 1, 'mapping email sent true';
+is $lane_email_5->is_assembly_email_sent(), 1, 'assembly email sent true';
+is $lane_email_5->is_annotation_email_sent(), 1, 'annotation email sent true';
 
 # previously unseen lane
 ok my $lane_email_unseen = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 9), 'initialize unseen lane';
 is $lane_email_unseen->is_qc_email_sent(), 0, 'qc email sent false';
 is $lane_email_unseen->is_mapping_email_sent(), 0, 'mapping email sent false';
+is $lane_email_unseen->is_assembly_email_sent(), 0, 'assembly email sent false';
+is $lane_email_unseen->is_annotation_email_sent(), 0, 'annotation email sent false';
 ok $lane_email_unseen->qc_email_sent(), 'send qc email';
 ok $lane_email_unseen->mapping_email_sent(), 'send mapping email';
+ok $lane_email_unseen->assembly_email_sent(), 'send assembly email';
+ok $lane_email_unseen->annotation_email_sent(), 'send annotation email';
 is $lane_email_unseen->is_qc_email_sent(), 1, 'qc email sent false';
 is $lane_email_unseen->is_mapping_email_sent(), 1, 'mapping email sent false';
+is $lane_email_unseen->is_assembly_email_sent(), 1, 'assembly email sent false';
+is $lane_email_unseen->is_annotation_email_sent(), 1, 'annotation email sent false';
 
 # look up unseen lane again (because it should now be stored in database
 ok $lane_email_unseen = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => 9), 'initialize unseen lane';
 is $lane_email_unseen->is_qc_email_sent(), 1, 'qc email sent false';
 is $lane_email_unseen->is_mapping_email_sent(), 1, 'mapping email sent false';
+is $lane_email_unseen->is_assembly_email_sent(), 1, 'assembly email sent false';
+is $lane_email_unseen->is_annotation_email_sent(), 1, 'annotation email sent false';

--- a/t/Study.t
+++ b/t/Study.t
@@ -4,7 +4,7 @@ use warnings;
 
 BEGIN { unshift(@INC, './lib') }
 BEGIN {
-    use Test::Most tests => 28;
+    use Test::Most tests => 52;
     use DBICx::TestDatabase;
     use PipelinesReporting::Schema;
     use_ok('PipelinesReporting::Study');
@@ -22,11 +22,11 @@ $dbh->resultset('Sample'     )->create({ row_id => 1, sample_id  => 3, project_i
 
 $dbh->resultset('Library'    )->create({ row_id => 1, library_id => 4, sample_id  => 3 });
 $dbh->resultset('Library'    )->create({ row_id => 2, library_id => 7, sample_id  => 3 });
-
-$dbh->resultset('Lane'       )->create({ row_id => 1, name => "abc_1", lane_id => 5, library_id => 4, processed => 15 });
+$dbh->resultset('Lane'       )->create({ row_id => 1, name => "abc_1", lane_id => 5, library_id => 4, processed => 5 });
 $dbh->resultset('Lane'       )->create({ row_id => 2, name => "abc_2", lane_id => 6, library_id => 4, processed => 11 });
 $dbh->resultset('Lane'       )->create({ row_id => 3, name => "abc_3", lane_id => 8, library_id => 7, processed => 11 });
-
+$dbh->resultset('Lane'       )->create({ row_id => 4, name => "abc_4", lane_id => 9, library_id => 7, processed => 1035 });
+$dbh->resultset('Lane'       )->create({ row_id => 5, name => "abc_5", lane_id => 10, library_id => 7, processed => 3083 });
 
 # valid study
 ok my $study = PipelinesReporting::Study->new(  
@@ -44,27 +44,56 @@ my @user_emails = ('aaa@example.com','bbb@example.com');
 is_deeply $study->user_emails, \@user_emails, 'user emails';
 
 my %qc_names  = (abc_2 => 6,
-                 abc_3 => 8);
+                 abc_3 => 8,
+                 abc_4 => 9,
+                 abc_5 => 10);
 is_deeply $study->qc_names, \%qc_names, 'qc lane ids';
 
 my %mapped_names = (abc_1 => 5);
 is_deeply $study->mapped_names, \%mapped_names, 'mapped lane ids';
 
+my %assembled_names = (abc_4 => 9,
+                       abc_5 => 10);
+is_deeply $study->assembled_names, \%assembled_names, 'assembled lane ids';
+
+my %annotated_names = (abc_5 => 10);
+is_deeply $study->annotated_names, \%annotated_names, 'annotated lane ids';
+
 ok my $lane_email_abc_1 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => "abc_1"), 'initialize lane_email 1 ';
 ok my $lane_email_abc_2 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => "abc_2"), 'initialize lane_email 2';
 ok my $lane_email_abc_3 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => "abc_3"), 'initialize lane_email 3';
+ok my $lane_email_abc_4 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => "abc_4"), 'initialize lane_email 4';
+ok my $lane_email_abc_5 = PipelinesReporting::LaneEmails->new(_dbh => $dbh,name => "abc_5"), 'initialize lane_email 5';
 
 is $lane_email_abc_1->is_qc_email_sent(), 0, 'qc email lane 1 sent false';
 is $lane_email_abc_2->is_qc_email_sent(), 1, 'qc email lane 2 sent true';
 is $lane_email_abc_3->is_qc_email_sent(), 1, 'qc email lane 3 sent true';
+is $lane_email_abc_4->is_qc_email_sent(), 1, 'qc email lane 4 sent true';
+is $lane_email_abc_5->is_qc_email_sent(), 1, 'qc email lane 5 sent true';
 
 is $lane_email_abc_1->is_mapping_email_sent(), 1, 'mapped email lane 1 sent true';
 is $lane_email_abc_2->is_mapping_email_sent(), 0, 'mapped email lane 2 sent false';
 is $lane_email_abc_3->is_mapping_email_sent(), 0, 'mapped email lane 3 sent false';
+is $lane_email_abc_4->is_mapping_email_sent(), 0, 'mapped email lane 4 sent false';
+is $lane_email_abc_5->is_mapping_email_sent(), 0, 'mapped email lane 5 sent false';
+
+is $lane_email_abc_1->is_assembly_email_sent(), 0, 'assembled email lane 1 sent false';
+is $lane_email_abc_2->is_assembly_email_sent(), 0, 'assembled email lane 2 sent false';
+is $lane_email_abc_3->is_assembly_email_sent(), 0, 'assembled email lane 3 sent false';
+is $lane_email_abc_4->is_assembly_email_sent(), 1, 'assembled email lane 4 sent true';
+is $lane_email_abc_5->is_assembly_email_sent(), 1, 'assembled email lane 5 sent true';
+
+is $lane_email_abc_1->is_annotation_email_sent(), 0, 'annotated email lane 1 sent false';
+is $lane_email_abc_2->is_annotation_email_sent(), 0, 'annotated email lane 2 sent false';
+is $lane_email_abc_3->is_annotation_email_sent(), 0, 'annotated email lane 3 sent false';
+is $lane_email_abc_4->is_annotation_email_sent(), 0, 'annotated email lane 4 sent true';
+is $lane_email_abc_5->is_annotation_email_sent(), 1, 'annotated email lane 5 sent true';
 
 # check body of constructed email
 my $expected_email_body = 'The following lanes have finished QC in Study Study Name.
 
+abc_4	http://example.com?mode=0&lane_id=9&db=test
+abc_5	http://example.com?mode=0&lane_id=10&db=test
 abc_2	http://example.com?mode=0&lane_id=6&db=test
 abc_3	http://example.com?mode=0&lane_id=8&db=test
 
@@ -80,7 +109,20 @@ abc_1	http://example.com?mode=0&lane_id=5&db=test
 ';
 is $study->_construct_email_body_for_lane_action('Mapping', $study->mapped_names), $expected_email_body, 'Mapping email body';
 
+$expected_email_body = 'The following lanes have finished Assembly in Study Study Name.
 
+abc_4	http://example.com?mode=0&lane_id=9&db=test
+abc_5	http://example.com?mode=0&lane_id=10&db=test
+
+';
+is $study->_construct_email_body_for_lane_action('Assembly', $study->assembled_names), $expected_email_body, 'Assembly email body';
+
+$expected_email_body = 'The following lanes have finished Annotation in Study Study Name.
+
+abc_5	http://example.com?mode=0&lane_id=10&db=test
+
+';
+is $study->_construct_email_body_for_lane_action('Annotation', $study->annotated_names), $expected_email_body, 'Annotation email body';
 
 ## error cases
 my @empty_array = ();
@@ -96,6 +138,8 @@ ok $study = PipelinesReporting::Study->new(
 is_deeply $study->user_emails, \@empty_array , 'user emails invalid study';
 is_deeply $study->qc_names, undef, 'qc lane ids undef if invalid study';
 is_deeply $study->mapped_names, undef, 'mapped lane ids undef if invalid study';
+is_deeply $study->assembled_names, undef, 'assembled lane ids undef if invalid study';
+is_deeply $study->annotated_names, undef, 'annotated lane ids undef if invalid study';
 
 ok $study = PipelinesReporting::Study->new(  
   _pipeline_dbh => $dbh,
@@ -126,3 +170,5 @@ my %empty_hash =();
 is_deeply $study->user_emails, \@user_emails, 'user emails has 1 user';
 is_deeply $study->qc_names, \%empty_hash, 'qc lane ids empty if no lanes';
 is_deeply $study->mapped_names, \%empty_hash, 'mapped lane ids empty if no lanes';
+is_deeply $study->assembled_names, \%empty_hash, 'assembled lane ids empty if no lanes';
+is_deeply $study->annotated_names, \%empty_hash, 'annotated lane ids empty if no lanes';


### PR DESCRIPTION
This PR extends the code in the repo so registered analysts receive emails once their lanes have been assembled and annotated (ticket 484202). I've also extended the range of processed flags used to designate QC and mapping having run as it's likely that we were missing some lanes from mails (over weekends in particular, given the cron timings,as it's feasible that a lane could import, QC, archive, map and assemble/annotate within 48 hours).